### PR TITLE
Handle related links blocks

### DIFF
--- a/Scrape.user.js
+++ b/Scrape.user.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name         Scrape
 // @namespace    http://tampermonkey.net/
-// @version      2025-07-10
-// @description  Scrape NYT articles for recipes
+// @version      2025-07-23
+// @description  Scrape NYT articles for recipes plus look for related-block recipes
 // @author       Me
 // @match        https://www.nytimes.com/*
 // @match        https://cooking.nytimes.com/article/*
@@ -19,43 +19,57 @@
 // ==/UserScript==
 
 (async function () {
-  'use strict'
+    'use strict'
 
-  const debug = false
+    const debug = false
 
-  function Log (text) {
-    // If debugging, write text to console.log
-    if (debug) {
-      console.log(text)
+    function Log (text) {
+        // If debugging, write text to console.log
+        if (debug) {
+            console.log(text)
+        }
     }
-  }
 
-  console.log('userscript Scrape entered')
-
-  // Create an object to send to the recipe-scraper application with information about the article
-  let Obj = { ID: 'artInfo' }
-
-  // Call function artScrape (in artScrape.js) to scrape the page for recipes
-  // eslint-disable-next-line no-undef
-  Obj = artScrape(Obj, debug)
-
-  Log('Scrape returnObj')
-  Log(Obj)
-
-  // Send the stringified object to the recipe-scraper application
-  // eslint-disable-next-line no-undef
-  GM_xmlhttpRequest({
-    method: 'POST',
-    url: 'http://localhost:8012',
-    data: JSON.stringify(Obj),
-    headers: {
-      'Content-Type': 'application/json; charset=UTF-8'
-    },
-    onload (response) {
-      const responseObj = JSON.parse(response.responseText)
-      if (responseObj.message === 'OK' && !debug) {
-        window.close()
-      }
+    // Send the object returned by artScrap to the recipe-scraper application. Return a promise. Upon receipt of a response, resolve the promise and
+    // open any candidate recipes (recipes extracted from related links blocks) in new tabs at half second intervals.
+    async function sendArticleObj (Obj) {
+        return new Promise (function (resolve) {
+            GM_xmlhttpRequest({
+                method: 'POST',
+                url: 'http://localhost:8012',
+                data: JSON.stringify(Obj),
+                headers: {
+                    'Content-Type': 'application/json; charset=UTF-8'
+                },
+                async onload (response) {
+                    const responseObj = JSON.parse(response.responseText)
+                    console.log('HTTP response messsage: ' + responseObj.message)
+                    resolve()
+                    for (const candidate of Obj.candidates) {
+                        GM_openInTab(candidate.url)
+                        await new Promise(resolve => setTimeout(resolve, 500))
+                    }
+                    if (responseObj.message === 'OK' && !debug) {
+                        window.close()
+                    }
+                }
+            })
+        })
     }
-  })
+
+    console.log('userscript ScrapePlus entered')
+
+    // Create an object to send to the recipe-scraper application with information about the article
+    let Obj = { ID: 'artInfo' }
+
+    // Call function artScrape (in artScrape.js) to scrape the page for recipes
+    // eslint-disable-next-line no-undef
+    Obj = await artScrape(Obj, debug)
+
+    Log('Scrape returnObj')
+    Log(Obj)
+
+    // Send the output of artScrape to the recipe-scraper application and open any candidate recipes in tabs.
+    await sendArticleObj(Obj)
+
 })()

--- a/change-log.txt
+++ b/change-log.txt
@@ -1,3 +1,40 @@
+?/24/2025
+    related-links branch
+    Change current.js
+    - function Mainline
+        -- Add function lauchChrome to spawn an instance of Chrome, to create a counters object, to create a Promise with resolvers object and to wait on that object's promise. The counters object is used to keep track of the articles and candidate recipes remaining to be processed. When everything has been processed, the Promise object's promise will be resolved, and launchChrome then sends an 'enable-review' message to the renderer process to enable the Review button.
+    - on.'openTP'
+        -- Call function launchChrome instead of spawning Chrome
+    - on.'process-date'
+        -- Call function launchChrome instead of spawning Chrome
+    - function requestListener
+        -- In case 'articleArray', add the number of articles to the counters object
+        -- In case 'artInfo', add 'await' to the call of function artInfo
+        -- Add case 'recipeRelatedArticle' to handle a recipe related article object sent by the reportCookingHref userscript.
+        -- In function artInfo,
+            --- move the response to the POST request to the end of the function,
+            --- add the number of candidate recipes found in the article to the counters object
+            --- decrement the count of acticles in the counters object
+        -- After the POST request has been processed, check the counters object to see if anything remains to be processed and if not, call the Promise object's resolve function.
+    Change current-preload.js
+        - Add onEnableReview for the enable-review message
+    Change current-renderer.js
+        - Add onEnableReview to enable the 'Review' button.
+        - Add a boolean noArticlesDisplayed initialized to true. It is used in onAddArticles for first-time actions, where it is set to false. It is reset to true in the 'Review' button event listener.
+    Change artScrape.javascript
+        - Make functions artScrape and getRecipes async.
+        - function getRecipes
+            -- Add code to extract recipes from div elements of class 'related-links-block'. Objects representing extracted recipes are added to an array, candidatesArray.
+            -- Add candidatesArray to the array returned by function getRecipes.
+        - Add 'await' to the call to function getRecipes
+        - Add the candidates array returned by function getRecipes to the returnObj object.
+    Change tpScrape.user.js
+        - Move the GM_xmlhttpRequest call to a new async function sendArticleArray, which returns a promise that is resolved by the response to the POST request.
+        - After awaiting function sendArticleArray, issue GM_openInTab for each article at 1 second intervals.
+    Change Scrape.js
+        - Move the GM_xmlhttpRequest call to a new async function sendArticleArray, which returns a promise that is resolved by the response to the POST request. After resolving the promise, open any candidate recipes returned in new tabs.
+    Add reportCookingHref.user.js
+        - Scrape an NYTCooking recipe for a 'featured in' article and return the result to the recipe-scraper application.
 7/17/2025
     Merge the manual click branch into the master branch
 7/17/2025

--- a/current-preload.js
+++ b/current-preload.js
@@ -45,6 +45,9 @@ contextBridge.exposeInMainWorld(
     onAddContinue: (fn) => {
       ipcRenderer.on('add-continue', (event, ...args) => fn(...args))
     },
+    onEnableReview: (fn) => {
+      ipcRenderer.on('enable-review', (event, ...args) => fn(...args))
+    },
     onEnableContinue: (fn) => {
       ipcRenderer.on('enable-continue', (event, ...args) => fn(...args))
     },

--- a/current-renderer.js
+++ b/current-renderer.js
@@ -1,7 +1,7 @@
 // This file is invoked by the current.html file and will
 // be executed in the renderer process for that window.
 
-//  Manual click version 3.1.0
+//  Related links version 3.3.0
 
 // Code structure:
 //
@@ -77,6 +77,7 @@ let articlesIndexArray = [] // Array of article indices of articles added to the
 let articleInfoObjsArray = [] // Array of article info objects sent from the main process
 let todaysPaperURL // URL of the date being processed Today's Paper page
 let removeDateListItem // true if processing a dateList element, false if date was picked
+let noArticlesDisplayed = true // true before any of a day's articles have been displayed
 
 // Function definitions
 
@@ -165,10 +166,10 @@ dateSpec.addEventListener('change', (evt) => {
 })
 
 reviewButton.addEventListener('click', async (evt) => {
-  // Process click on the Submit button
+  // Process click on the Review button
   evt.preventDefault()
   console.log('Mainline: Review button clicked, disable Review button')
-  reviewButton.classList.add('disabled') // Disable the Submit button
+  reviewButton.classList.add('disabled') // Disable the Review button
 
   document.removeEventListener('click', articleClick)
   const ckd = document.querySelectorAll('input:checked') // Get checked articles
@@ -182,10 +183,11 @@ reviewButton.addEventListener('click', async (evt) => {
   while (aL.firstChild) {
     aL.removeChild(aL.lastChild)
   }
+  noArticlesDisplayed = true
   articlesIndexArray = [] // Reset array of article indices added to the window
   articleInfoObjsArray = [] // Reset array of article info objects sent from the main process
   if (removeDateListItem) {
-    // Remove the submitted articles' date from the dateList
+    // Remove the article's date from the dateList
     Array.from(datesList.querySelectorAll('a')).filter((el) => el.getAttribute('href') === todaysPaperURL)[0].remove()
   }
   window.scraper.send('AOT', false) // Set the window's 'always on top' attribute to false
@@ -235,9 +237,9 @@ window.scraper.onAddArticles((event, artInfoObjString) => {
   const cbTitle = article.querySelector('.article')
   const cbAuthor = article.querySelector('.author')
 
-  // If the Submit button is disabled, this is the first article being added. Enable the button, add an event listener for clicks on articles and set the window's 'always on top' attribute to true
-  if (reviewButton.classList.contains('disabled')) {
-    reviewButton.classList.remove('disabled')
+  // If noArticlesDisplayed is true, this is the first article being added. Add an event listener for clicks on articles and set the window's 'always on top' attribute to true
+  if (noArticlesDisplayed) {
+    noArticlesDisplayed = false
     document.addEventListener('click', articleClick)
     window.scraper.send('AOT', true)
   }
@@ -258,7 +260,7 @@ window.scraper.onAddArticles((event, artInfoObjString) => {
   const followingArticleIndex = articlesIndexArray.findIndex((element) => element > artInfo.index)
   Log('Indices: ' + artInfo.index + ', ' + followingArticleIndex)
   if (followingArticleIndex === -1) {
-    // If no such index is foudn, add the article to the end of the article list
+    // If no such index is found, add the article to the end of the article list
     aL.appendChild(article)
   } else {
     // Otherwise, insert this article before the article whose index was found
@@ -324,6 +326,12 @@ window.scraper.onAddContinue(() => {
   sub.value = 'Continue'
   sub.disabled = true
   aL.appendChild(sub)
+})
+
+window.scraper.onEnableReview(() => {
+  // Enable the 'Review' button
+  Log('enable-review entered')
+  reviewButton.classList.remove('disabled') // Disable the Submit button
 })
 
 window.scraper.onEnableContinue(() => {

--- a/reportCookingHref.user.js
+++ b/reportCookingHref.user.js
@@ -1,0 +1,46 @@
+// ==UserScript==
+// @name         reportCookingHref
+// @namespace    http://tampermonkey.net/
+// @version      2025-07-23
+// @description  Send an NYT Cooking recipe's related article URL to the recipe-scraper application
+// @author       You
+// @match        https://cooking.nytimes.com/recipes/*
+// @icon         https://www.google.com/s2/favicons?sz=64&domain=cooking.nytimes.com
+// @grant        GM_xmlhttpRequest
+// ==/UserScript==
+
+(function() {
+    'use strict';
+
+    console.log('Userscript reportCookingHref entered')
+    const debug = false
+
+    const location = window.location
+    const recipeURL = location.href.split('?', 1)[0]
+
+    const Obj = {
+                  ID: 'recipeRelatedArticle',
+                  recipeURL: recipeURL
+                }
+
+    const relatedLink = document.querySelector('p[class^="topnote_relatedArticle"] a')
+    if (relatedLink) {
+        Obj.relatedArticleURL = relatedLink.href
+        console.log('relatedArticleURL: ' + Obj.relatedArticleURL)
+    }
+
+    GM_xmlhttpRequest({
+      method: 'POST',
+      url: 'http://localhost:8012',
+      data: JSON.stringify(Obj),
+      headers: {
+        'Content-Type': 'application/json; charset=UTF-8'
+      },
+      onload (response) {
+        const responseObj = JSON.parse(response.responseText)
+        if (responseObj.message === 'OK' && !debug) {
+          window.close()
+        }
+      }
+    })
+})();


### PR DESCRIPTION
NYT food articles occasionally place links to NYT Cooking recipes in a "related links" block. The content of these blocks is not loaded until the block is scrolled into view.  This change adds code to detect related links blocks and retrieve recipes from them.